### PR TITLE
Enable overriding of assembly version attributes from pack.sh

### DIFF
--- a/Fuse.targets
+++ b/Fuse.targets
@@ -1,4 +1,12 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup>
+		<Compile Condition="!Exists('$(MSBuildThisFileDirectory)\Source\GlobalAssemblyInfo.Override.cs')" Include="$(MSBuildThisFileDirectory)\Source\GlobalAssemblyInfo.cs">
+			<Link>Properties\GlobalAssemblyInfo.cs</Link>
+		</Compile>
+		<Compile Condition="Exists('$(MSBuildThisFileDirectory)\Source\GlobalAssemblyInfo.Override.cs')" Include="$(MSBuildThisFileDirectory)\Source\GlobalAssemblyInfo.Override.cs">
+			<Link>Properties\GlobalAssemblyInfo.Override.cs</Link>
+		</Compile>
+	</ItemGroup>
 	<UsingTask TaskName="Outracks.Fuse.BuildTasks.BundleApp" AssemblyFile="Source/Fusion/BuildTasks/bin/$(Configuration)/Outracks.Fuse.BuildTasks.dll" />
 
 	<PropertyGroup>

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -1,6 +1,0 @@
-using System.Reflection;
-
-[assembly: AssemblyCompany("Fusetools")]
-[assembly: AssemblyCopyright("Copyright © 2017 Fusetools AS")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]

--- a/Source/.gitignore
+++ b/Source/.gitignore
@@ -1,0 +1,1 @@
+GlobalAssemblyInfo.Override.cs

--- a/Source/AndroidManager/Outracks.AndroidManager.csproj
+++ b/Source/AndroidManager/Outracks.AndroidManager.csproj
@@ -100,9 +100,6 @@
     <Compile Include="ProcessHelper.cs" />
     <Compile Include="ProgressExtension.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="SdkConfigOptions.cs" />
     <Compile Include="VerifyCommand.cs" />
     <Compile Include="ZipHelper.cs" />

--- a/Source/AndroidManager/Properties/AssemblyInfo.cs
+++ b/Source/AndroidManager/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("AndroidManager")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("AndroidManager")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("95f53cbb-39fe-48df-9977-716d07330287")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0")]

--- a/Source/CodeCompletion/Outracks.CodeCompletion.CodeNinja.Tests/Outracks.CodeCompletion.CodeNinja.Tests.csproj
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.CodeNinja.Tests/Outracks.CodeCompletion.CodeNinja.Tests.csproj
@@ -218,9 +218,6 @@
     <Compile Include="Tests\TryCatch.cs" />
     <Compile Include="Tests\Using_.cs" />
     <Compile Include="Tests\Using_Static.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Core\Outracks.Common.Core.csproj">

--- a/Source/CodeCompletion/Outracks.CodeCompletion.CodeNinja.Tests/Properties/AssemblyInfo.cs
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.CodeNinja.Tests/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.CodeNinja.Tests")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.CodeNinja.Tests")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("eb8d222f-0d59-4f15-847e-9bad49b73623")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/CodeCompletion/Outracks.CodeCompletion.CodeNinja/Outracks.CodeCompletion.CodeNinja.csproj
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.CodeNinja/Outracks.CodeCompletion.CodeNinja.csproj
@@ -200,9 +200,6 @@
     <Compile Include="GoToDefinition.cs" />
     <Compile Include="ParameterInfoSuggester.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Core\Outracks.Common.Core.csproj">

--- a/Source/CodeCompletion/Outracks.CodeCompletion.CodeNinja/Properties/AssemblyInfo.cs
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.CodeNinja/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.CodeCompletion.CodeNinja")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.CodeCompletion.CodeNinja")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("e17583f0-acd1-4184-bf67-6ecb79e05a2b")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/CodeCompletion/Outracks.CodeCompletion.NRefactoryInterop/Outracks.CodeCompletion.NRefactoryInterop.csproj
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.NRefactoryInterop/Outracks.CodeCompletion.NRefactoryInterop.csproj
@@ -118,9 +118,6 @@
     <Compile Include="UXNinja\ElementContext.cs" />
     <Compile Include="UXNinja\NRefactoryExtensions.cs" />
     <Compile Include="UXNinja\SourceEntityFactoryUX.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\3rdparty\NRefactory\ICSharpCode.NRefactory.Xml\ICSharpCode.NRefactory.Xml.csproj">

--- a/Source/CodeCompletion/Outracks.CodeCompletion.NRefactoryInterop/Properties/AssemblyInfo.cs
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.NRefactoryInterop/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.CodeCompletionFactory")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("CodeCompletionFactory")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("5ab4611a-0ac2-4799-a25d-8970f3ab2988")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.PerformanceTests.Client/Outracks.CodeCompletion.UXNinja.PerformanceTests.Client.csproj
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.PerformanceTests.Client/Outracks.CodeCompletion.UXNinja.PerformanceTests.Client.csproj
@@ -46,9 +46,6 @@
     <Compile Include="BasicTypes\Mono.Options\Options.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Outracks.CodeCompletion.UXNinja.PerformanceTests.Core\Outracks.CodeCompletion.UXNinja.PerformanceTests.Core.csproj">

--- a/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.PerformanceTests.Client/Properties/AssemblyInfo.cs
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.PerformanceTests.Client/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.CodeCompletion.UXNinja.PerformanceTests.Client")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.CodeCompletion.UXNinja.PerformanceTests.Client")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("1a1b4039-304c-4168-a6bb-2e46d82a75f3")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.PerformanceTests.Core/Outracks.CodeCompletion.UXNinja.PerformanceTests.Core.csproj
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.PerformanceTests.Core/Outracks.CodeCompletion.UXNinja.PerformanceTests.Core.csproj
@@ -158,9 +158,6 @@
     <Compile Include="TestBase.cs" />
     <Compile Include="Runner\PerformanceTestRunner.cs" />
     <Compile Include="Context\UxPerformanceTestContext.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Outracks.CodeCompletion.CodeNinja\Outracks.CodeCompletion.CodeNinja.csproj">

--- a/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.PerformanceTests.Core/Properties/AssemblyInfo.cs
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.PerformanceTests.Core/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.CodeCompletion.UXNinja.PerformanceTests.Core")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.CodeCompletion.UXNinja.PerformanceTests.Core")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("b7df1d41-e570-4ce6-89a5-cb8f799f1920")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.PerformanceTests/Outracks.CodeCompletion.UXNinja.PerformanceTests.csproj
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.PerformanceTests/Outracks.CodeCompletion.UXNinja.PerformanceTests.csproj
@@ -46,9 +46,6 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SomeTest.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Outracks.CodeCompletion.UXNinja.PerformanceTests.Core\Outracks.CodeCompletion.UXNinja.PerformanceTests.Core.csproj">

--- a/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.PerformanceTests/Properties/AssemblyInfo.cs
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.PerformanceTests/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.CodeCompletion.UXNinja.PerformanceTests")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.CodeCompletion.UXNinja.PerformanceTests")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("68faca4f-7c8d-4a3c-81b4-8d7ab5a45f44")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.Tests/Outracks.CodeCompletion.UXNinja.Tests.csproj
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.Tests/Outracks.CodeCompletion.UXNinja.Tests.csproj
@@ -149,9 +149,6 @@
     <Compile Include="Tests\StartAttributeName.cs" />
     <Compile Include="Tests\StartTagName.cs" />
     <Compile Include="Tests\ValueSuggestion.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Outracks.CodeCompletion.NRefactoryInterop\Outracks.CodeCompletion.NRefactoryInterop.csproj">

--- a/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.Tests/Properties/AssemblyInfo.cs
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.Tests/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Uno.UXNinja.Tests")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Uno.UXNinja.Tests")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("f56d2aea-57a4-4cb2-9c54-cbdb76cafa60")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.TestsCommon/Outracks.CodeCompletion.UXNinja.TestsCommon.csproj
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.TestsCommon/Outracks.CodeCompletion.UXNinja.TestsCommon.csproj
@@ -79,9 +79,6 @@
     <Compile Include="DummySource.cs" />
     <Compile Include="DummySourcePackage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Outracks.CodeCompletion.CodeNinja\Outracks.CodeCompletion.CodeNinja.csproj">

--- a/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.TestsCommon/Properties/AssemblyInfo.cs
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja.TestsCommon/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.CodeCompletion.UXNinja.TestsCommon")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.CodeCompletion.UXNinja.TestsCommon")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("bc1eb6f5-08cb-4159-a222-9b1599740a89")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja/Outracks.CodeCompletion.UXNinja.csproj
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja/Outracks.CodeCompletion.UXNinja.csproj
@@ -78,9 +78,6 @@
     <Compile Include="SuggestionHelper.cs" />
     <Compile Include="SuggestionParser.cs" />
     <Compile Include="TokenType.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Outracks.CodeCompletion.CodeNinja\Outracks.CodeCompletion.CodeNinja.csproj">

--- a/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja/Properties/AssemblyInfo.cs
+++ b/Source/CodeCompletion/Outracks.CodeCompletion.UXNinja/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.UnoDevelop.UXNinja")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.UnoDevelop.UXNinja")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("dd829263-8c31-49d7-afeb-eb936bdfb447")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/CodeCompletion/Outracks.CodeCompletion/Outracks.CodeCompletion.csproj
+++ b/Source/CodeCompletion/Outracks.CodeCompletion/Outracks.CodeCompletion.csproj
@@ -80,9 +80,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SuggestItem.cs" />
     <Compile Include="SyntaxLanguage.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Core\Outracks.Common.Core.csproj">

--- a/Source/CodeCompletion/Outracks.CodeCompletion/Properties/AssemblyInfo.cs
+++ b/Source/CodeCompletion/Outracks.CodeCompletion/Properties/AssemblyInfo.cs
@@ -1,28 +1,2 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.CodeCompletion")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.CodeCompletion")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("8a63076c-e0a6-4fe0-9870-a164728d9683")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/Common/Core/Outracks.Common.Core.csproj
+++ b/Source/Common/Core/Outracks.Common.Core.csproj
@@ -202,9 +202,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Diagnostics\ManualProfiling.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="ValidationResult.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Common/Core/Properties/AssemblyInfo.cs
+++ b/Source/Common/Core/Properties/AssemblyInfo.cs
@@ -1,30 +1,5 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.Common")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.Common")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("32837e09-0faf-4be1-9c3c-492cf81780f0")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: InternalsVisibleTo("Outracks.Common.Tests")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/Common/Core/SystemInfo/SystemInfoFactory.cs
+++ b/Source/Common/Core/SystemInfo/SystemInfoFactory.cs
@@ -7,30 +7,9 @@ namespace Outracks
 {
 	public static class SystemInfoFactory
 	{
-		public static Version GetBuildVersion()
+		public static string GetBuildVersion(Assembly assembly)
 		{
-			try
-			{
-				return GetVersion(Assembly.GetExecutingAssembly());
-			}
-			catch (Exception)
-			{
-				return new Version(0, 0, 0, 0);
-			}
-		}
-
-		static Version GetVersion(Assembly assembly)
-		{
-			try
-			{
-				var fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
-				var version = fileVersionInfo.ProductVersion;
-				return new Version(version);
-			}
-			catch (Exception)
-			{
-				return new Version(0,0,0,0);
-			}
+			return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "0.0.0-dev";
 		}
 	}
 }

--- a/Source/Common/Math/Outracks.Common.Math.csproj
+++ b/Source/Common/Math/Outracks.Common.Math.csproj
@@ -105,9 +105,6 @@
     <Compile Include="Units\Points.cs" />
     <Compile Include="Units\TextureSpaceUnits.cs" />
     <Compile Include="Vector.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Source/Common/Math/Properties/AssemblyInfo.cs
+++ b/Source/Common/Math/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.Common.Math")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.Common.Math")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("0fb6c6a6-a618-4ada-91c9-c991f9ece099")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/Common/Tests/Outracks.Common.Tests.csproj
+++ b/Source/Common/Tests/Outracks.Common.Tests.csproj
@@ -82,9 +82,6 @@
     <Compile Include="Paths\FilePathTests.cs" />
     <Compile Include="Pipes\UnixSocketStreamTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="RemoteTaskTest.cs" />
     <Compile Include="ReplayQueueSubjectTest.cs" />
     <Compile Include="ReportTest.cs" />

--- a/Source/Common/Tests/Properties/AssemblyInfo.cs
+++ b/Source/Common/Tests/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.Common.Tests")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.Common.Tests")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("483789eb-24dc-4739-905e-9a48e3525777")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/Common/Text/Outracks.Common.Text.csproj
+++ b/Source/Common/Text/Outracks.Common.Text.csproj
@@ -60,9 +60,6 @@
     <Compile Include="TextPosition.cs" />
     <Compile Include="TextRegion.cs" />
     <Compile Include="TextScanner.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Math\Outracks.Common.Math.csproj">

--- a/Source/Common/Text/Properties/AssemblyInfo.cs
+++ b/Source/Common/Text/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.Common.Text")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.Common.Text")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("cf23cd86-d289-4cbd-987e-f8d2509c7265")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/Fuse/Command/Commands/DashboardCommand.cs
+++ b/Source/Fuse/Command/Commands/DashboardCommand.cs
@@ -24,7 +24,7 @@ namespace Outracks.Fuse
 				outWriter: ColoredTextWriter.Out);
 		}
 
-		readonly Version _fuseVersion;
+		readonly string _fuseVersion;
 		readonly IFileSystem _fs;
 		readonly IReport _log;
 		readonly IFuseLauncher _launchFuse;
@@ -33,7 +33,7 @@ namespace Outracks.Fuse
 		readonly AbsoluteFilePath _versionFile;
 
 		public DashboardCommand(
-			Version fuseVersion,
+			string fuseVersion,
 			IFileSystem fs,
 			IReport log,
 			IFuseLauncher launchFuse, 
@@ -80,20 +80,20 @@ namespace Outracks.Fuse
 			}			
 		}
 
-		bool ShouldKillFuse(Version version)
+		bool ShouldKillFuse(string version)
 		{
 			if (Platform.OperatingSystem != OS.Mac)
 				return false;
 
-			var currentInstalledVersion = GetCurrentInstalledVersion().Or(new Version());
+			var currentInstalledVersion = GetCurrentInstalledVersion().Or("0.0.0-dev");
 			return currentInstalledVersion != version;
 		}
 
-		Optional<Version> GetCurrentInstalledVersion()
+		Optional<string> GetCurrentInstalledVersion()
 		{
 			try
 			{
-				return Version.Parse(_fs.ReadAllText(_versionFile, 5));
+				return _fs.ReadAllText(_versionFile, 5);
 			}
 			catch (Exception e)
 			{
@@ -102,11 +102,11 @@ namespace Outracks.Fuse
 			}					
 		}
 
-		bool TryWriteCurrentVersion(Version version)
+		bool TryWriteCurrentVersion(string version)
 		{
 			try
 			{
-				_fs.ReplaceText(_versionFile, version.ToString(4), 5);
+				_fs.ReplaceText(_versionFile, version, 5);
 				return true;
 			}
 			catch (Exception e)

--- a/Source/Fuse/Command/Outracks.Fuse.Command.csproj
+++ b/Source/Fuse/Command/Outracks.Fuse.Command.csproj
@@ -208,9 +208,6 @@
     <Compile Include="TableWriter.cs" />
     <Compile Include="UnknownCommand.cs" />
     <Compile Include="UnoConfigExtensions.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="VersionWriter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Fuse/Command/Program.cs
+++ b/Source/Fuse/Command/Program.cs
@@ -118,9 +118,9 @@ namespace Outracks.Fuse
 			}
 		}
 
-		static void WriteVersion(this TextWriter writer, Version version)
+		static void WriteVersion(this TextWriter writer, string version)
 		{
-			writer.WriteLine("Fuse version " + version.ToString(3) + " (build " + version.Revision + ")");
+			writer.WriteLine("Fuse version " + version);
 			writer.WriteLine("Copyright (C) 2017 Fusetools");
 		}
 

--- a/Source/Fuse/Command/Properties/AssemblyInfo.cs
+++ b/Source/Fuse/Command/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.Fuse.Bootstrap")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.Fuse.Bootstrap")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("28e84230-e61a-4fe6-b5c5-85e42d890814")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/Fuse/Command/VersionWriter.cs
+++ b/Source/Fuse/Command/VersionWriter.cs
@@ -5,9 +5,9 @@ namespace Outracks.Fuse
 {
 	public static class VersionWriter
 	{
-		public static void Write(TextWriter textWriter, Version version)
+		public static void Write(TextWriter textWriter, string version)
 		{
-			textWriter.WriteLine(string.Format("Fuse {0}.{1}.{2} (build {3})", version.Major, version.Minor, version.Build, version.Revision));
+			textWriter.WriteLine("Fuse {0}", version);
 		}
 	}
 }

--- a/Source/Fuse/Common/FuseApi.cs
+++ b/Source/Fuse/Common/FuseApi.cs
@@ -86,11 +86,14 @@ namespace Outracks.Fuse
 				: fuseRoot / new FileName("Fuse.exe"));
 
 			var unoExe = FindUnoExe(fuseRoot);
-				
+
+			var version = SystemInfoFactory.GetBuildVersion(typeof(FuseApi).Assembly);
+
+
 			var impl = new FuseImpl
 			{
 				FuseRoot = fuseRoot,
-				Version = SystemInfoFactory.GetBuildVersion(),
+				Version = version,
 
 				UnoExe = unoExe,
 				FuseExe = fuseExe,

--- a/Source/Fuse/Common/FuseImpl.cs
+++ b/Source/Fuse/Common/FuseImpl.cs
@@ -51,8 +51,8 @@ namespace Outracks.Fuse
 			get { return Diagnostics.Platform.OperatingSystem; }
 		}
 
-		public Version Version { get; set; }
-		public bool IsInstalled { get { return Version != new Version(1, 0, 0, 0); } }
+		public string Version { get; set; }
+		public bool IsInstalled { get { return Version.Contains("-dev"); } }
 
 
 		public AbsoluteDirectoryPath FuseRoot { get; set; }

--- a/Source/Fuse/Common/IFuse.cs
+++ b/Source/Fuse/Common/IFuse.cs
@@ -8,7 +8,7 @@ namespace Outracks.Fuse
 	public interface IFuse : IFuseLauncher
 	{
 		OS Platform { get; }
-		Version Version { get; }
+		string Version { get; }
 		bool IsInstalled { get; }
 
 		Guid SystemId { get; }

--- a/Source/Fuse/Common/Outracks.Fuse.Common.csproj
+++ b/Source/Fuse/Common/Outracks.Fuse.Common.csproj
@@ -93,9 +93,6 @@
     <Compile Include="ProjectDetector.cs" />
     <Compile Include="ProjectNotFound.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Protocol\Building\BuildEnded.cs" />
     <Compile Include="Protocol\Building\BuildIssueDetected.cs" />
     <Compile Include="Protocol\Building\BuildLogged.cs" />

--- a/Source/Fuse/Common/Properties/AssemblyInfo.cs
+++ b/Source/Fuse/Common/Properties/AssemblyInfo.cs
@@ -1,30 +1,5 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.FuseEditor")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.FuseEditor")]
 [assembly: InternalsVisibleTo("Outracks.Fuse.Protocol.Tests")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("a904f287-d09f-495c-aa39-d212b8a6f975")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/Fuse/Daemon/Outracks.Fuse.Daemon.csproj
+++ b/Source/Fuse/Daemon/Outracks.Fuse.Daemon.csproj
@@ -69,9 +69,6 @@
     <Compile Include="Identity.cs" />
     <Compile Include="ReadUntilExtension.cs" />
     <Compile Include="ServiceRunner.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\AndroidManager\Outracks.AndroidManager.csproj">

--- a/Source/Fuse/Daemon/Properties/AssemblyInfo.cs
+++ b/Source/Fuse/Daemon/Properties/AssemblyInfo.cs
@@ -1,28 +1,6 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Outracks.Fuse.Daemon")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.Fuse.Daemon")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("b4c3ca13-463b-40b6-b113-9dc088d570ae")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/Fuse/Notifier/Outracks.Fuse.Notifier.csproj
+++ b/Source/Fuse/Notifier/Outracks.Fuse.Notifier.csproj
@@ -103,9 +103,6 @@
     </None>
     <InterfaceDefinition Include="MainMenu.xib" />
     <None Include="packages.config" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Math\Outracks.Common.Math.csproj">

--- a/Source/Fuse/Notifier/Program.cs
+++ b/Source/Fuse/Notifier/Program.cs
@@ -43,7 +43,7 @@ namespace Outracks.Fuse.Notifier
 							: "Outracks.Fuse.Notifier.Resources.Fuse.ico")),
 				menu:
 					Menu.Item(
-						"Fuse v. " + fuse.Version.ToString(3) + " (build " + fuse.Version.Revision + ")",
+						"Fuse v. " + fuse.Version,
 						command: Command.Disabled)
 					+ Menu.Separator
 					+ Menu.Item(

--- a/Source/Fuse/Notifier/Properties/AssemblyInfo.cs
+++ b/Source/Fuse/Notifier/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.Fuse.TrayApplication")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.Fuse.TrayApplication")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("3b95e6a5-45d8-4289-b7b3-0f59efa2c1df")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/Fuse/Sandbox/Outracks.Fuse.Sandbox.csproj
+++ b/Source/Fuse/Sandbox/Outracks.Fuse.Sandbox.csproj
@@ -58,9 +58,6 @@
     <Compile Include="AutoReloadContent.cs" />
     <Compile Include="AutoReloadProgram.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Core\Outracks.Common.Core.csproj">

--- a/Source/Fuse/Sandbox/Properties/AssemblyInfo.cs
+++ b/Source/Fuse/Sandbox/Properties/AssemblyInfo.cs
@@ -1,32 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Fusion-AutoReload")]
 [assembly: AssemblyDescription("An auto-reload tool for fusion, see README.md for usage.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Fusion-AutoReload")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("aa63d2f1-e4b1-4a0f-8092-63524e252229")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/Fuse/Studio/About.cs
+++ b/Source/Fuse/Studio/About.cs
@@ -7,7 +7,7 @@ namespace Outracks.Fuse.Designer
 {
 	public class About {
 
-		public About(Version version, Debug debug)
+		public About(string version, Debug debug)
 		{
 			var showAboutDialog = new BehaviorSubject<bool>(false);
 

--- a/Source/Fuse/Studio/Dashboard/Dashboard.cs
+++ b/Source/Fuse/Studio/Dashboard/Dashboard.cs
@@ -22,7 +22,7 @@ namespace Outracks.Fuse.Dashboard
 					Style = WindowStyle.Fat,
 					Title = Observable.Return("Fuse"),
 					Size = Optional.Some(Property.Constant(Optional.Some(new Size<Points>(970, 608)))),
-					Content = Control.Lazy(() => CreateContent(createProject, window,fuse.Version)),
+					Content = Control.Lazy(() => CreateContent(createProject, window, fuse.Version)),
 					Foreground = Theme.DefaultText,
 					Background = Theme.PanelBackground,
 					Border = Separator.MediumStroke,
@@ -36,7 +36,7 @@ namespace Outracks.Fuse.Dashboard
 			_isVisible.OnNext(true);
 		}
 
-		IControl CreateContent(CreateProject createProject, IDialog<object> dialog,  Version fuseVersion)
+		IControl CreateContent(CreateProject createProject, IDialog<object> dialog,  string fuseVersion)
 		{
 			var projectList = new ProjectList(new Shell(), createProject, dialog);
 			var openProjectFromDialog =
@@ -116,10 +116,10 @@ namespace Outracks.Fuse.Dashboard
 					left: new Points(16));
 		}
 
-		private static IControl CreateDashTopBar(Version fuseVersion)
+		private static IControl CreateDashTopBar(string fuseVersion)
 		{
 
-			var versionStr = "V" + fuseVersion.ToString(2);
+			var versionStr = "V" + fuseVersion;
 
 			return
 				Layout.Dock()
@@ -135,7 +135,7 @@ namespace Outracks.Fuse.Dashboard
 										versionStr,
 										color: Theme.DescriptorText,
 										font: Theme.DefaultFont)
-									.SetToolTip("Version " + fuseVersion.ToString(4)),
+									.SetToolTip("Version " + fuseVersion),
 								Label.Create(
 										"Fuse Studio",
 										color: Theme.DefaultText,

--- a/Source/Fuse/Studio/Outracks.Fuse.Studio.csproj
+++ b/Source/Fuse/Studio/Outracks.Fuse.Studio.csproj
@@ -409,9 +409,6 @@
     <Compile Include="MainWindow\Inspector\Inspector.cs" />
     <Compile Include="MainWindow\MainWindow.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="$(SolutionDir)\SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Theming\Theme.cs" />
     <Compile Include="MainWindow\Stage\ViewportController.cs" />
     <Compile Include="MainWindow\Stage\ViewportFactory.cs" />

--- a/Source/Fuse/Studio/Properties/AssemblyInfo.cs
+++ b/Source/Fuse/Studio/Properties/AssemblyInfo.cs
@@ -1,34 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Fuse Studio")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Fuse Studio")]
 [assembly: InternalsVisibleTo("Outracks.Fuse.Protocol.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("9635527a-9e21-4161-8b2c-e9f7f5797a02")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/Fuse/Studio/Theming/LogoAndVersion.cs
+++ b/Source/Fuse/Studio/Theming/LogoAndVersion.cs
@@ -6,9 +6,9 @@ namespace Outracks.Fuse.Designer
 {
 	public static class LogoAndVersion
 	{
-		public static IControl Create(Version fuseVersion)
+		public static IControl Create(string fuseVersion)
 		{
-			var versionStr = "Version " + fuseVersion.ToString(3) + " (build " + fuseVersion.Revision + ")";
+			var versionStr = "Version " + fuseVersion;
 			return Layout.StackFromTop(
 				Image.FromResource("Outracks.Fuse.Icons.FuseProLogo.png", typeof(LogoAndVersion).Assembly, Theme.DefaultText)
 					.WithSize(new Size<Points>(336 * 0.65, 158 * 0.65))

--- a/Source/Fuse/Tests/Outracks.Fuse.Tests.csproj
+++ b/Source/Fuse/Tests/Outracks.Fuse.Tests.csproj
@@ -187,9 +187,6 @@
     <Compile Include="MessageDatabaseItem.cs" />
     <Compile Include="MessageIntegrityTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Refactoring\ClassExtractorTests.cs" />
     <Compile Include="Refactoring\ExtractClassButtonViewModelTests.cs" />
     <Compile Include="Refactoring\ExtractClassViewModelTests.cs" />

--- a/Source/Fuse/Tests/Properties/AssemblyInfo.cs
+++ b/Source/Fuse/Tests/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.Fuse.Protocol.Tests")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.Fuse.Protocol.Tests")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("7d150d54-f2bb-4161-b1c6-96cf8597d116")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/Fuse/Tests/VersionWriterTests.cs
+++ b/Source/Fuse/Tests/VersionWriterTests.cs
@@ -11,9 +11,9 @@ namespace Outracks.Common.CLI.Tests
 		[Test]
 		public void WritesVersion()
 		{
-			var writer = Substitute.For<TextWriter>();
-			VersionWriter.Write(writer, new Version(1, 2, 3, 4));
-			writer.Received().WriteLine("Fuse 1.2.3 (build 4)");
+			var writer = new StringWriter() {  NewLine = "\n" };
+			VersionWriter.Write(writer, "1.2.3-moo");
+			Assert.AreEqual("Fuse 1.2.3-moo\n", writer.ToString());
 		}
 	}
 }

--- a/Source/Fusion/BuildTasks/Outracks.Fusion.BuildTasks.csproj
+++ b/Source/Fusion/BuildTasks/Outracks.Fusion.BuildTasks.csproj
@@ -35,9 +35,6 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="BundleMono.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Source/Fusion/BuildTasks/Properties/AssemblyInfo.cs
+++ b/Source/Fusion/BuildTasks/Properties/AssemblyInfo.cs
@@ -1,15 +1,3 @@
 using System.Reflection;
-// Information about this assembly is defined by the following attributes.
-// Change them to the values specific to your project.
 [assembly: AssemblyTitle ("Outracks.Fuse.BuildTasks")]
 [assembly: AssemblyDescription ("")]
-[assembly: AssemblyConfiguration ("")]
-[assembly: AssemblyProduct ("")]
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-[assembly: AssemblyVersion ("1.0.*")]
-// The following attributes are used to specify the signing key for the assembly,
-// if desired. See the Mono documentation for more information about signing.
-//[assembly: AssemblyDelaySign(false)]
-//[assembly: AssemblyKeyFile("")]

--- a/Source/Fusion/Core/Outracks.Fusion.Core.csproj
+++ b/Source/Fusion/Core/Outracks.Fusion.Core.csproj
@@ -205,9 +205,6 @@
     <Compile Include="Menus\MenuItem.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Menus\Menu.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="DropOperation.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Fusion/Core/Properties/AssemblyInfo.cs
+++ b/Source/Fusion/Core/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.Controls")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.Controls")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("e6021db1-1802-4e07-b612-a742a03926bd")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/Fusion/IntegrationTests/Properties/AssemblyInfo.cs
+++ b/Source/Fusion/IntegrationTests/Properties/AssemblyInfo.cs
@@ -7,30 +7,3 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Outracks.Fusion.IntegrationTests")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Outracks.Fusion.IntegrationTests")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("580ba299-adad-43c1-86a7-63e60f345f28")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/Fusion/Mac/Outracks.Fusion.Mac.csproj
+++ b/Source/Fusion/Mac/Outracks.Fusion.Mac.csproj
@@ -113,9 +113,6 @@
     <Compile Include="AppDelegate.designer.cs">
       <DependentUpon>AppDelegate.cs</DependentUpon>
     </Compile>
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="ShellOSX.cs" />
     <Compile Include="ToolTipImplementation.cs" />
     <Compile Include="WindowImplementation.cs" />

--- a/Source/Fusion/Mac/Properties/AssemblyInfo.cs
+++ b/Source/Fusion/Mac/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.Fuse.Native-OSX")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.Fuse.Native-OSX")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("ca39bc1d-3667-414a-80ce-8a6b8e25f16a")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/Fusion/Windows/Outracks.Fusion.Windows.csproj
+++ b/Source/Fusion/Windows/Outracks.Fusion.Windows.csproj
@@ -137,9 +137,6 @@
     <Compile Include="FileDialogs.cs" />
     <Compile Include="FilterString.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="WindowsMenuBuilder.cs" />
     <Compile Include="WpfCommand.cs" />
   </ItemGroup>

--- a/Source/Fusion/Windows/Properties/AssemblyInfo.cs
+++ b/Source/Fusion/Windows/Properties/AssemblyInfo.cs
@@ -1,31 +1,5 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Windows.Media;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.Fuse.Native-Windows")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.Fuse.Native-Windows")]
 [assembly: DisableDpiAwareness]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("25ec48dc-e415-4d66-9e2f-9b9fcdc0f959")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/GlobalAssemblyInfo.cs
+++ b/Source/GlobalAssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyCompany("Fusetools")]
+[assembly: AssemblyProduct("Fuse Studio")]
+[assembly: AssemblyCopyright("Copyright © 2015-2018 Fusetools")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+[assembly: AssemblyVersion("1.9.0.0")]
+[assembly: AssemblyFileVersion("1.9.0.0")]
+[assembly: AssemblyInformationalVersion("1.9.0-dev")]

--- a/Source/Outracks.Fuse.CodeAssistanceService/Outracks.Fuse.CodeAssistanceService.csproj
+++ b/Source/Outracks.Fuse.CodeAssistanceService/Outracks.Fuse.CodeAssistanceService.csproj
@@ -178,9 +178,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SuggestionsFeature.cs" />
     <Compile Include="SyntaxLanguage.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Source/Outracks.Fuse.CodeAssistanceService/Properties/AssemblyInfo.cs
+++ b/Source/Outracks.Fuse.CodeAssistanceService/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Fuse.CodeAssistanceService")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.Fuse.CodeAssistanceService")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("d7106df7-efd9-4fdb-843a-4a8981d4ed29")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/Outracks.Fuse.Startup-OSX/Outracks.Fuse.Startup-OSX.csproj
+++ b/Source/Outracks.Fuse.Startup-OSX/Outracks.Fuse.Startup-OSX.csproj
@@ -188,9 +188,6 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Entrypoint.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Source/Outracks.Fuse.Startup-OSX/Properties/AssemblyInfo.cs
+++ b/Source/Outracks.Fuse.Startup-OSX/Properties/AssemblyInfo.cs
@@ -1,18 +1,3 @@
 using System.Reflection;
-using System.Runtime.CompilerServices;
-// Information about this assembly is defined by the following attributes.
-// Change them to the values specific to your project.
 [assembly: AssemblyTitle ("Outracks.Fuse.Startup-OSX")]
 [assembly: AssemblyDescription ("")]
-[assembly: AssemblyConfiguration ("")]
-[assembly: AssemblyProduct ("Outracks.Fuse.Startup-OSX")]
-// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
-// The form "{Major}.{Minor}.*" will automatically update the build and revision,
-// and "{Major}.{Minor}.{Build}.*" will update just the revision.
-[assembly: AssemblyVersion ("1.0.0")]
-[assembly: AssemblyFileVersion ("1.0.0")]
-// The following attributes are used to specify the signing key for the assembly,
-// if desired. See the Mono documentation for more information about signing.
-//[assembly: AssemblyDelaySign(false)]
-//[assembly: AssemblyKeyFile("")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/Outracks.Fuse.Startup-Windows/Outracks.Fuse.Startup-Windows.csproj
+++ b/Source/Outracks.Fuse.Startup-Windows/Outracks.Fuse.Startup-Windows.csproj
@@ -183,9 +183,6 @@
   <ItemGroup>
     <Compile Include="Entrypoint.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fuse\Command\Outracks.Fuse.Command.csproj">

--- a/Source/Outracks.Fuse.Startup-Windows/Properties/AssemblyInfo.cs
+++ b/Source/Outracks.Fuse.Startup-Windows/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Fuse")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.Fuse.Startup-Windows")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("0cccb6f9-f043-4245-b7bc-402f6f31b8ea")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/Outracks.TriggerFuseQuit/Outracks.TriggerFuseQuit.csproj
+++ b/Source/Outracks.TriggerFuseQuit/Outracks.TriggerFuseQuit.csproj
@@ -39,9 +39,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">

--- a/Source/Outracks.TriggerFuseQuit/Properties/AssemblyInfo.cs
+++ b/Source/Outracks.TriggerFuseQuit/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.TriggerFuseQuit")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.TriggerFuseQuit")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("bf6d3dff-08ad-4ba6-88d2-40ee8a57f9f3")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/Preview/Core/Fuse.Preview.Core.csproj
+++ b/Source/Preview/Core/Fuse.Preview.Core.csproj
@@ -73,9 +73,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EmptyClass.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Source/Preview/Service/CacheCleaner.cs
+++ b/Source/Preview/Service/CacheCleaner.cs
@@ -7,9 +7,9 @@ namespace Fuse.Preview
 	public class CacheCleaner
 	{
 		readonly IFileSystem _fs;		
-		readonly Version _version;
+		readonly string _version;
 
-		public CacheCleaner(IFileSystem fs, Version version)
+		public CacheCleaner(IFileSystem fs, string version)
 		{
 			_fs = fs;
 			_version = version;
@@ -29,9 +29,7 @@ namespace Fuse.Preview
 			if (!_fs.Exists(versionFile))
 				return true;
 
-			Version version;
-			if (!Version.TryParse(_fs.ReadAllText(versionFile, 3), out version))
-				return true;
+			string version = _fs.ReadAllText(versionFile, 3);
 
 			if (version != _version)
 				return true;
@@ -45,7 +43,7 @@ namespace Fuse.Preview
 			{
 				_fs.Delete(cacheDirectory);
 				_fs.Create(cacheDirectory);
-				WriteVersion(versionFile, _version);	
+				WriteVersion(versionFile, _version);
 			}
 			catch (IOException) { }
 			catch (UnauthorizedAccessException) { }		
@@ -53,7 +51,7 @@ namespace Fuse.Preview
 
 		/// <exception cref="IOException"></exception>
 		/// <exception cref="UnauthorizedAccessException"></exception>
-		void WriteVersion(AbsoluteFilePath versionFile, Version version)
+		void WriteVersion(AbsoluteFilePath versionFile, string version)
 		{
 			using(var stream = _fs.Create(versionFile))
 			using (var streamWriter = new StreamWriter(stream))

--- a/Source/Preview/Service/Fuse.Preview.Service.csproj
+++ b/Source/Preview/Service/Fuse.Preview.Service.csproj
@@ -235,9 +235,6 @@
     <Compile Include="RunFailed.cs" />
     <Compile Include="SimulatorBuild.cs" />
     <Compile Include="SimulatorHost.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="SocketServer.cs" />
     <Compile Include="SourceToSourceReference.cs" />
     <Compile Include="Started.cs" />

--- a/Source/Preview/Service/ProjectProcess.cs
+++ b/Source/Preview/Service/ProjectProcess.cs
@@ -5,6 +5,7 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Reflection;
 using Outracks;
+using Outracks.Fuse;
 using Outracks.Fuse.Analytics;
 using Outracks.IO;
 using Outracks.Simulator.Protocol;
@@ -65,7 +66,7 @@ namespace Fuse.Preview
 
 			var input = ReadInput(inputPipe);
 
-			var output = Run(input, new Version());
+			var output = Run(input, SystemInfoFactory.GetBuildVersion(typeof(FuseApi).Assembly));
 
 			using (output.WriteOutput(outputPipe))
 			using (input.Connect())
@@ -88,7 +89,7 @@ namespace Fuse.Preview
 				messages.Subscribe(message => message.WriteTo(writer)));
 		}
 
-		public static IObservable<IBinaryMessage> Run(IObservable<IBinaryMessage> input, Version version)
+		public static IObservable<IBinaryMessage> Run(IObservable<IBinaryMessage> input, string version)
 		{
 			var builder = new Builder(new UnoBuild(version));
 			var reifier = new Reifier(builder);

--- a/Source/Preview/Service/Properties/AssemblyInfo.cs
+++ b/Source/Preview/Service/Properties/AssemblyInfo.cs
@@ -1,31 +1,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.Simulator.Proxy")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.Simulator.Proxy")]
 [assembly: InternalsVisibleTo("Fuse.Preview.Tests")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("fbb5ff79-b93c-48f6-a50a-6e94f2dd3de8")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]
 [assembly: InternalsVisibleTo("Fuse.Preview.Tests")]

--- a/Source/Preview/Service/UnoBuild.cs
+++ b/Source/Preview/Service/UnoBuild.cs
@@ -18,7 +18,7 @@ namespace Fuse.Preview
 		#pragma warning disable 0414
 		LockFile lockFile = null;
 		#pragma warning restore 0414
-		public UnoBuild(Version version)
+		public UnoBuild(string version)
 		{
 			_fileSystem = new Shell();
 			var cacheCleaner = new CacheCleaner(_fileSystem, version);

--- a/Source/Preview/Service/UnoBuildWrapper.cs
+++ b/Source/Preview/Service/UnoBuildWrapper.cs
@@ -29,7 +29,7 @@ namespace Fuse.Preview
 		#pragma warning disable 0414
 		static LockFile lockFile = null;
 		#pragma warning restore 0414
-		public static UnoBuildWrapper Create(IFileSystem shell, Version version, IObserver<IBinaryMessage> buildEvents, bool isHost, params IErrorHelper[] errorHelpers)
+		public static UnoBuildWrapper Create(IFileSystem shell, string version, IObserver<IBinaryMessage> buildEvents, bool isHost, params IErrorHelper[] errorHelpers)
 		{
 			var cacheCleaner = new CacheCleaner(shell, version);
 			var simulatorBuilder = new SimulatorBuilder(shell, cacheCleaner, isHost: isHost, registerLock: (e) => lockFile = e);

--- a/Source/Simulator/Common/Outracks.Simulator.Common.csproj
+++ b/Source/Simulator/Common/Outracks.Simulator.Common.csproj
@@ -83,9 +83,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EmptyClass.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
     <None Include="Messages\BytecodeGenerated.cs" />
     <None Include="Messages\BytecodeUpdated.cs" />
     <None Include="Bytecode\Exceptions.cs" />

--- a/Source/Simulator/Main/Outracks.Simulator.Main.csproj
+++ b/Source/Simulator/Main/Outracks.Simulator.Main.csproj
@@ -219,9 +219,6 @@
     <Compile Include="ExpressionConverter.cs" />
     <Compile Include="ProjectObjectIdentifiers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Runtime\DotNetBuild.cs" />
     <Compile Include="Runtime\DotNetReflection.cs" />
     <Compile Include="Runtime\MemoizingTypeMap.cs" />

--- a/Source/Simulator/Main/Properties/AssemblyInfo.cs
+++ b/Source/Simulator/Main/Properties/AssemblyInfo.cs
@@ -1,30 +1,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
+
 [assembly: AssemblyTitle("Outracks.Simulator.Host")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.Simulator.Host")]
 [assembly: InternalsVisibleTo("Outracks.Simulator.Tests")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("f9d00c0d-504f-4a31-8610-dd1bb8dfcba2")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/UnoHost/Common/Outracks.UnoHost.Common.csproj
+++ b/Source/UnoHost/Common/Outracks.UnoHost.Common.csproj
@@ -79,9 +79,6 @@
     <Compile Include="Input\MouseButtons.cs" />
     <Compile Include="Input\ModifierKeys.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="$(SolutionDir)SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="UnoHandles\GraphicsContextHandleImpl.cs" />
     <Compile Include="UnoHandles\PlatformWindowHandleImpl.cs" />
     <Compile Include="UnoHostControl.cs" />

--- a/Source/UnoHost/Common/Properties/AssemblyInfo.cs
+++ b/Source/UnoHost/Common/Properties/AssemblyInfo.cs
@@ -1,28 +1,3 @@
 using System.Reflection;
-using System.Runtime.InteropServices;
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.Fuse.Native.UnoCoreInterop")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.Fuse.Native.UnoCoreInterop")]
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("adcf62a4-a8ce-4cfa-aa2d-16421582a8a0")]
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/Source/UnoHost/Mac/Outracks.UnoHost.Mac.csproj
+++ b/Source/UnoHost/Mac/Outracks.UnoHost.Mac.csproj
@@ -99,9 +99,6 @@
     <Compile Include="UnoView\MonoMacEnums.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="$(SolutionDir)\SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="Protocol\CocoaEventMessage.cs" />
     <Compile Include="UnoView\RenderTargets\IOSurfaceTexture.cs" />
     <Compile Include="DisplayLinkView.cs" />

--- a/Source/UnoHost/Mac/Properties/AssemblyInfo.cs
+++ b/Source/UnoHost/Mac/Properties/AssemblyInfo.cs
@@ -1,32 +1,5 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.UnoHost.OSX")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.UnoHost.OSX")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("4a60b851-adce-4e9c-8e4c-efb8d0cdaa71")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/UnoHost/Windows/Outracks.UnoHost.Windows.csproj
+++ b/Source/UnoHost/Windows/Outracks.UnoHost.Windows.csproj
@@ -105,9 +105,6 @@
     <Compile Include="OpenTKGL.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="$(SolutionDir)\SharedAssemblyInfo.cs">
-      <Link>Properties/SharedAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="UnoHostControlImplementation.cs" />
     <Compile Include="UnoControl.cs">
       <SubType>UserControl</SubType>

--- a/Source/UnoHost/Windows/Properties/AssemblyInfo.cs
+++ b/Source/UnoHost/Windows/Properties/AssemblyInfo.cs
@@ -1,33 +1,5 @@
 ﻿using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Windows.Media;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Outracks.UnoHost.Windows")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyProduct("Outracks.UnoHost.Windows")]
 [assembly: DisableDpiAwareness]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("553a5f7e-d3b0-4ec6-adbe-093c5d6f5051")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Tools/update-assembly-info.sh
+++ b/Tools/update-assembly-info.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+SELF=`echo $0 | sed 's/\\\\/\\//g'`
+cd "`dirname "$SELF"`/.."
+
+function override-assembly-info {
+	local version=$1
+	# Extract the X.Y.Z part of version, removing the suffix if any
+	local version_triplet=`echo $version | sed -n -e 's/\([^-]*\).*/\1/p'`
+
+	# Start with updating the local GlobalAssemblyInfo.Override.cs
+	sed -e 's/\(AssemblyVersion("\)[^"]*\(")\)/\1'$version_triplet'\2/' \
+		  -e 's/\(AssemblyFileVersion("\)[^"]*\(")\)/\1'$version_triplet'\2/' \
+		  -e 's/\(AssemblyInformationalVersion("\)[^"]*\(")\)/\1'$version'\2/' \
+		  Source/GlobalAssemblyInfo.cs > Source/GlobalAssemblyInfo.Override.cs
+}
+
+if [ -n "$1" ]; then
+	override-assembly-info "$1"
+else
+	echo "Usage: $0 <version>"
+	exit 1
+fi
+

--- a/pack.sh
+++ b/pack.sh
@@ -8,6 +8,8 @@ else
     VERSION=$(cat VERSION.txt)"-local"
 fi
 
+Tools/update-assembly-info.sh $VERSION
+
 DST="`pwd -P`/Release"
 rm -rf "$DST"
 
@@ -194,3 +196,6 @@ if [ "$DO_ZIP" = "1" ]; then
     echo -e "\nRESULT: $ZIP"
 
 fi
+
+rm -f Source/GlobalAssemblyInfo.Override.cs
+


### PR DESCRIPTION
Need this to build the `1.9.0-rc1` installer with correct version number.