### PR TITLE
Build Windows installer on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,15 +1,19 @@
-version: 1.0.{build}
+version: '{build}'
+image: Visual Studio 2017
 
+clone_depth: 1
+
+platform: Any CPU
 configuration: Release
 
-image: Visual Studio 2017
-platform: Any CPU
+before_build:
+  - if defined APPVEYOR_REPO_TAG_NAME set VERSION_TAG=%APPVEYOR_REPO_TAG_NAME:~1%
+  - if not defined APPVEYOR_REPO_TAG_NAME set VERSION_TAG=%APPVEYOR_REPO_BRANCH%
+  - bash update-assembly-info.sh
 
 build:
   project: Fuse-Win32.sln
   verbosity: normal
-
-clone_depth: 1
 
 test:
   assemblies:
@@ -23,3 +27,17 @@ test:
       - Source\Preview\Tests\bin\$(configuration)\Fuse.Preview.Tests.dll
       - Source\Simulator\Tests\bin\$(configuration)\Outracks.Simulator.Tests.dll
       - Source\UnoHost\Tests\bin\$(configuration)\Outracks.UnoHost.Common.Tests.dll
+
+after_build:
+  - bash build-windows-installer.sh 
+
+artifacts:
+  - path: Installer\Windows\BuildOutput\Release\FuseSetup.exe
+    name: Fuse-$(VERSION_TAG)-Win32
+
+deploy:
+  - provider: GitHub
+    auth_token:
+      secure: XSoc3Kto6ZdFfpL4d0Kxmiins6AttcF2oysozoZwmkz9SAGtpnCeCjxpKwxpsua/ # TODO: This is Lorents' personal token
+    on:
+      appveyor_repo_tag: true 

--- a/Installer/Windows/Fuse.Installer.Product/Fuse.Installer.Product.wixproj
+++ b/Installer/Windows/Fuse.Installer.Product/Fuse.Installer.Product.wixproj
@@ -12,15 +12,10 @@
     <Name>Fuse.Installer.Product</Name>
 	<SuppressIces>ICE38;ICE64;ICE91</SuppressIces>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+  <PropertyGroup>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;FUSE_SOURCE_PATH=$(SolutionDir)\Source\Fuse;PACKAGES_SOURCE_PATH=$(SolutionDir)\Source\Packages;</DefineConstants> 
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <OutputPath>bin\$(Configuration)\</OutputPath>
-    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;FUSE_SOURCE_PATH=$(SolutionDir)\Source\Fuse;PACKAGES_SOURCE_PATH=$(SolutionDir)\Source\Packages;</DefineConstants>
+    <DefineConstants>Debug;FUSE_SOURCE_PATH=$(SolutionDir)\..\..\Release;PACKAGES_SOURCE_PATH=$(SolutionDir)\..\..\Release\Packages;</DefineConstants> 
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FuseData.wxs" />

--- a/Installer/Windows/Installer.msbuild
+++ b/Installer/Windows/Installer.msbuild
@@ -25,7 +25,7 @@
 	</UsingTask>
 
 	<PropertyGroup>
-		<SourcePath>$(MSBuildProjectDirectory)\Source\</SourcePath>
+		<SourcePath>$(MSBuildProjectDirectory)\..\..\Release\</SourcePath>
 		<InstallerProjectPath>$(MSBuildProjectDirectory)\Fuse.Installer.Product\</InstallerProjectPath>
 		<ReleaseConfiguration Condition="'$(ReleaseConfiguration)' == ''">Release</ReleaseConfiguration>
 	</PropertyGroup>
@@ -50,11 +50,11 @@
 	</Target>
 
 	<Target Name="SeparatePackages">
-		<Exec Command="robocopy $(SourcePath)/Fuse/Packages $(SourcePath)/Packages /move /e /log:movePackages.log" IgnoreExitCode="true" />
+		<!--<Exec Command="robocopy $(SourcePath)/Fuse/Packages $(SourcePath)/Packages /move /e /log:movePackages.log" IgnoreExitCode="true" />-->
 	</Target>
 
 	<Target Name="HarvestFuse">
-		<Exec Command="$(WixInstallPath)\heat.exe dir &quot;$(SourcePath)Fuse&quot; -t &quot;$(InstallerProjectPath)FuseDataFilter.xslt&quot; -var var.FUSE_SOURCE_PATH -dr INSTALLFOLDER -cg FuseData -ag -scom -sreg -nologo -ke -sfrad -srd -o &quot;$(InstallerProjectPath)FuseData.wxs&quot;" />
+		<Exec Command="$(WixInstallPath)\heat.exe dir &quot;$(SourcePath).&quot; -t &quot;$(InstallerProjectPath)FuseDataFilter.xslt&quot; -var var.FUSE_SOURCE_PATH -dr INSTALLFOLDER -cg FuseData -ag -scom -sreg -nologo -ke -sfrad -srd -o &quot;$(InstallerProjectPath)FuseData.wxs&quot;" />
 	</Target>
 
 	<Target Name="HarvestPackages">

--- a/build-windows-installer.sh
+++ b/build-windows-installer.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+set -e
+cd "`dirname "$0"`"
+
+OS_NAME="Win32"
+VERSION=$(cat VERSION.txt)"-local"
+
+DST="`pwd -P`/Release"
+rm -rf "$DST"
+
+CP="cp -f"
+UNO_VER=`cat .unoversion`
+UNO="$DST/Uno"
+PACKAGES="$DST/Packages"
+MODULES="$DST/Modules"
+mkdir -p "$UNO" "$PACKAGES"
+
+# Uno
+echo "Copying Uno executables to '$UNO'"
+$CP -R packages/FuseOpen.Uno.Tool.$UNO_VER/tools/* "$UNO"
+$CP -R packages/FuseOpen.Uno.Tool.$UNO_VER/tools/.unoconfig "$UNO"
+
+# Templates
+echo "Copying Uno project templates to '$DST/Templates'"
+mkdir -p "$DST/Templates"
+$CP -R Templates/* "$DST/Templates"
+
+# Modules
+echo "Copying Sublime Text 3 plugin installer scripts to '$DST/Modules'"
+mkdir -p "$DST/Modules"
+$CP -R Modules/* "$DST/Modules"
+
+# Warm up package installs to include what's needed to preview an app on .NET out-of-the-box.
+echo "Fetching Uno packages needed for a regular app"
+Stuff/uno create App -cApp -f
+Stuff/uno build dotnet App
+rm -rf App
+
+# Packages
+echo "Copying Uno packages to '$DST'"
+$CP Stuff/*.packages "$DST"
+$CP -R Stuff/lib/* "$PACKAGES"
+
+# Fuse.unoconfig
+echo "Write '$UNO/Fuse.unoconfig'"
+cat <<EOF >> "$UNO/Fuse.unoconfig"
+
+SimulatorDll: Fuse.Simulator.dll
+TemplatesDirectory: Templates
+ModulesDirectory: Modules
+
+// Package manager config
+Packages.InstallDirectory: "%LOCALAPPDATA%/Fusetools/Packages"
+Packages.SearchPaths += Packages
+Packages.LockFiles += [
+    uno.packages
+    fuselibs.packages
+    premiumlibs.packages
+]
+
+// SDK config
+SdkConfig: %LOCALAPPDATA%/Fusetools/Fuse/Android/.sdkconfig
+include %LOCALAPPDATA%/Fusetools/Fuse/Android/.sdkconfig
+
+//Extra unoconfig
+include "%LOCALAPPDATA%/Fusetools/Fuse/extra.unoconfig"
+EOF
+
+mv "$UNO"/* "$UNO/.unoconfig" "$DST"
+rm -rf "$UNO"
+
+# Fuse.exe
+echo "Copying Studio executables and libraries '$DST'"
+$CP bin/Release/*.dll "$DST"
+$CP bin/Release/*.exe "$DST"
+
+# Simulator client uno project
+echo "Copying Uno packages needed for preview to '$PACKAGES'"
+$CP -r Source/Simulator/build/* "$PACKAGES"
+$CP -r Source/Preview/build/* "$PACKAGES"
+
+# Delete debug symbols to avoid bloating the installers
+echo "Stripping debug symbol files"
+find "$DST" -name "*.pdb" -exec rm {} \; || :
+find "$DST" -name "*.mdb" -exec rm {} \; || :
+
+echo "Building installer..."
+cd "Installer"
+cd "Windows"
+cmd //c "BuildFinalInstaller.bat"
+
+echo "All done!"


### PR DESCRIPTION
Still awaiting how we update the assembly info (hence update-assembly-info.sh is empty)

Parts of pack.sh is currently copied into build-windows-installer.sh, however we could unify more of that code when we know what is needed for the mac installer on the new CI (the zipping shouldn't be needed anymore i think, and also i think it's fine to assume you've built the solution before building any of the installers)