### PR TITLE
Android: upgrade sdk-tools

### DIFF
--- a/Source/AndroidManager/AndroidSDKInstaller.cs
+++ b/Source/AndroidManager/AndroidSDKInstaller.cs
@@ -19,8 +19,8 @@ namespace Outracks.AndroidManager
 		{
 			_installPath = installPath;
 			_downloadUrl = Platform.OperatingSystem == OS.Windows
-				? new Uri("https://go.fusetools.com/android-sdk-win-2")
-				: new Uri("https://go.fusetools.com/android-sdk-osx-2");
+				? new Uri("https://dl.google.com/android/repository/sdk-tools-windows-4333796.zip")
+				: new Uri("https://dl.google.com/android/repository/sdk-tools-darwin-4333796.zip");
 			_fileSystem = fileSystem;
 		}
 

--- a/Source/AndroidManager/AndroidSDKPackageInstaller.cs
+++ b/Source/AndroidManager/AndroidSDKPackageInstaller.cs
@@ -10,13 +10,11 @@ namespace Outracks.AndroidManager
 	class AndroidPackageInstallResult
 	{
 		public readonly AbsoluteDirectoryPath NdkBundle;
-		public readonly AbsoluteDirectoryPath CMake;
 		public readonly string BuildToolsVersion;
-		public AndroidPackageInstallResult(AbsoluteDirectoryPath ndkBundle, string buildToolsVersion, AbsoluteDirectoryPath cmake)
+		public AndroidPackageInstallResult(AbsoluteDirectoryPath ndkBundle, string buildToolsVersion)
 		{
 			NdkBundle = ndkBundle;
 			BuildToolsVersion = buildToolsVersion;
-			CMake = cmake;
 		}
 	}
 
@@ -54,7 +52,6 @@ namespace Outracks.AndroidManager
 			{
 				"platform-tools",
 				"build-tools;23.0.1",
-				"cmake;3.6.4111459",
 				"ndk-bundle",
 				"extras;android;m2repository",
 				"extras;google;m2repository"
@@ -62,8 +59,7 @@ namespace Outracks.AndroidManager
 
 			return new AndroidPackageInstallResult(
 				_androidSdkRoot / new DirectoryName("ndk-bundle"),
-				TryGetBuildToolsVersion().OrThrow(new InstallerError("Couldn't find build tools version")),
-				_androidSdkRoot / new DirectoryName("cmake"));
+				TryGetBuildToolsVersion().OrThrow(new InstallerError("Couldn't find build tools version")));
 		}
 
 		void UpdateTools(CancellationToken ct, IProgress<InstallerEvent> progress, string package)

--- a/Source/AndroidManager/AndroidSDKPackageInstaller.cs
+++ b/Source/AndroidManager/AndroidSDKPackageInstaller.cs
@@ -56,8 +56,6 @@ namespace Outracks.AndroidManager
 				"build-tools;23.0.1",
 				"cmake;3.6.4111459",
 				"ndk-bundle",
-				"platforms;android-21",
-				"platforms;android-23",
 				"extras;android;m2repository",
 				"extras;google;m2repository"
 			}, ct, installerProgress);

--- a/Source/AndroidManager/AndroidSDKPackageInstaller.cs
+++ b/Source/AndroidManager/AndroidSDKPackageInstaller.cs
@@ -10,11 +10,10 @@ namespace Outracks.AndroidManager
 	class AndroidPackageInstallResult
 	{
 		public readonly AbsoluteDirectoryPath NdkBundle;
-		public readonly string BuildToolsVersion;
-		public AndroidPackageInstallResult(AbsoluteDirectoryPath ndkBundle, string buildToolsVersion)
+
+		public AndroidPackageInstallResult(AbsoluteDirectoryPath ndkBundle)
 		{
 			NdkBundle = ndkBundle;
-			BuildToolsVersion = buildToolsVersion;
 		}
 	}
 
@@ -51,15 +50,13 @@ namespace Outracks.AndroidManager
 			InstallPackages(new []
 			{
 				"platform-tools",
-				"build-tools;23.0.1",
 				"ndk-bundle",
 				"extras;android;m2repository",
 				"extras;google;m2repository"
 			}, ct, installerProgress);
 
 			return new AndroidPackageInstallResult(
-				_androidSdkRoot / new DirectoryName("ndk-bundle"),
-				TryGetBuildToolsVersion().OrThrow(new InstallerError("Couldn't find build tools version")));
+				_androidSdkRoot / new DirectoryName("ndk-bundle"));
 		}
 
 		void UpdateTools(CancellationToken ct, IProgress<InstallerEvent> progress, string package)
@@ -115,18 +112,6 @@ namespace Outracks.AndroidManager
 
 			if (exitCode != 0)
 				throw new InstallerError("Failed to install package '" + package + "'");
-		}
-
-		Optional<string> TryGetBuildToolsVersion()
-		{
-			var buildToolsFolder = _androidSdkRoot / new DirectoryName("build-tools");
-			if (!_fs.Exists(buildToolsFolder))
-				return Optional.None();
-
-			var buildToolsPackages = AndroidSDKPackageParser.SearchForPackagesIn(_fs, buildToolsFolder);
-			var latestPackage = buildToolsPackages.OrderBy(p => p.SortableRevision).LastOrNone();
-
-			return latestPackage.Select(package => package.OriginalRevision);
 		}
 
 		Optional<Version> TryGetToolsVersion()

--- a/Source/AndroidManager/AndroidSDKValidator.cs
+++ b/Source/AndroidManager/AndroidSDKValidator.cs
@@ -52,8 +52,6 @@ namespace Outracks.AndroidManager
 			{
 				if (!IsPlatformToolsInstalled(progress, installPath)) return false;
 
-				if (!IsBuildToolsInstalled(progress, installPath)) return false;
-
 				if (!IsAndroidSupportRepositoryInstalled(progress, installPath)) return false;
 
 				if (!IsGoogleRepositoryInstalled(progress, installPath)) return false;
@@ -76,16 +74,6 @@ namespace Outracks.AndroidManager
 		{
 			var basePath = installPath / new DirectoryName("ndk-bundle");
 			return _fs.Exists(basePath / new FileName("package.xml"));
-		}
-
-		public bool IsBuildToolsInstalled(IProgress<InstallerEvent> progress, AbsoluteDirectoryPath installPath)
-		{
-			if (!_fs.Exists(installPath / new DirectoryName("build-tools")))
-			{
-				progress.Report(new InstallerMessage("Android Build Tools was not found and is required"));
-				return false;
-			}
-			return true;
 		}
 
 		public bool IsPlatformToolsInstalled(IProgress<InstallerEvent> progress, AbsoluteDirectoryPath installPath)

--- a/Source/AndroidManager/AndroidSDKValidator.cs
+++ b/Source/AndroidManager/AndroidSDKValidator.cs
@@ -54,10 +54,6 @@ namespace Outracks.AndroidManager
 
 				if (!IsBuildToolsInstalled(progress, installPath)) return false;
 
-				if (!IsAndroidPlatformInstalled(progress, installPath, 21)) return false;
-
-				if (!IsAndroidPlatformInstalled(progress, installPath, 23)) return false;
-
 				if (!IsAndroidSupportRepositoryInstalled(progress, installPath)) return false;
 
 				if (!IsGoogleRepositoryInstalled(progress, installPath)) return false;
@@ -88,17 +84,6 @@ namespace Outracks.AndroidManager
 		{
 			var basePath = installPath / new DirectoryName("cmake");
 			return _fs.Exists(basePath);
-		}
-
-		public bool IsAndroidPlatformInstalled(IProgress<InstallerEvent> progress, AbsoluteDirectoryPath installPath, int version, Optional<string> extraInfo = default(Optional<string>))
-		{
-			var basePath = installPath / new DirectoryName("platforms") / new DirectoryName("android-" + version);
-			if (!_fs.Exists(basePath / new FileName("package.xml")))
-			{
-				progress.Report(new InstallerMessage("Android Platform " + version + " was not found and is required. " + extraInfo.Or("")));
-				return false;
-			}
-			return true;
 		}
 
 		public bool IsBuildToolsInstalled(IProgress<InstallerEvent> progress, AbsoluteDirectoryPath installPath)

--- a/Source/AndroidManager/AndroidSDKValidator.cs
+++ b/Source/AndroidManager/AndroidSDKValidator.cs
@@ -60,8 +60,6 @@ namespace Outracks.AndroidManager
 
 				if (!IsNdkInstalled(installPath)) return false;
 
-				if (!IsCmakeInstalled(installPath)) return false;
-
 				return true;
 			}
 			catch (InstallerError)
@@ -78,12 +76,6 @@ namespace Outracks.AndroidManager
 		{
 			var basePath = installPath / new DirectoryName("ndk-bundle");
 			return _fs.Exists(basePath / new FileName("package.xml"));
-		}
-
-		public bool IsCmakeInstalled(AbsoluteDirectoryPath installPath)
-		{
-			var basePath = installPath / new DirectoryName("cmake");
-			return _fs.Exists(basePath);
 		}
 
 		public bool IsBuildToolsInstalled(IProgress<InstallerEvent> progress, AbsoluteDirectoryPath installPath)

--- a/Source/AndroidManager/InstallCommand.cs
+++ b/Source/AndroidManager/InstallCommand.cs
@@ -112,8 +112,7 @@ namespace Outracks.AndroidManager
 				{
 					if (config.HaveAllSdkPackages 
 						&& config.AndroidNdkDirectory.HasValue 
-						&& config.AndroidSdkBuildToolsVersion.HasValue 
-						&& config.CMake.HasValue)
+						&& config.AndroidSdkBuildToolsVersion.HasValue)
 						return;
 
 					var installer = new AndroidSDKPackageInstaller(
@@ -130,7 +129,6 @@ namespace Outracks.AndroidManager
 
 					config.AndroidNdkDirectory = result.NdkBundle;
 					config.AndroidSdkBuildToolsVersion = result.BuildToolsVersion;
-					config.CMake = result.CMake;
 				});
 		}
 

--- a/Source/AndroidManager/InstallCommand.cs
+++ b/Source/AndroidManager/InstallCommand.cs
@@ -111,8 +111,7 @@ namespace Outracks.AndroidManager
 				androidRoot =>
 				{
 					if (config.HaveAllSdkPackages 
-						&& config.AndroidNdkDirectory.HasValue 
-						&& config.AndroidSdkBuildToolsVersion.HasValue)
+						&& config.AndroidNdkDirectory.HasValue)
 						return;
 
 					var installer = new AndroidSDKPackageInstaller(
@@ -128,7 +127,6 @@ namespace Outracks.AndroidManager
 					var result = installer.Install(CancellationToken.None, _dialog, _progress);
 
 					config.AndroidNdkDirectory = result.NdkBundle;
-					config.AndroidSdkBuildToolsVersion = result.BuildToolsVersion;
 				});
 		}
 

--- a/Source/AndroidManager/SdkConfigOptions.cs
+++ b/Source/AndroidManager/SdkConfigOptions.cs
@@ -17,9 +17,6 @@ namespace Outracks.AndroidManager
 		[JsonProperty("Android.SDK.BuildToolsVersion")]
 		public string AndroidSdkBuildToolsVersion = null;
 
-		[JsonProperty("CMake")]
-		public string CMake = null;
-
 		[JsonProperty("HaveAllSDKPackages")]
 		public bool HaveAllSdkPackages = false;
 	}
@@ -29,7 +26,6 @@ namespace Outracks.AndroidManager
 		public Optional<AbsoluteDirectoryPath> AndroidSdkDirectory;
 		public Optional<AbsoluteDirectoryPath> AndroidNdkDirectory;
 		public Optional<AbsoluteDirectoryPath> JavaJdkDirectory;
-		public Optional<AbsoluteDirectoryPath> CMake;
 		public Optional<string> AndroidSdkBuildToolsVersion;
 		public bool HaveAllSdkPackages;
 
@@ -38,14 +34,12 @@ namespace Outracks.AndroidManager
 			Optional<AbsoluteDirectoryPath> androidNdkDirectory, 
 			Optional<AbsoluteDirectoryPath> javaJdkDirectory, 
 			Optional<string> androidSdkBuildToolsVersion, 
-			Optional<AbsoluteDirectoryPath> cmake,
 			bool haveAllSdkPackages)
 		{
 			AndroidSdkDirectory = androidSdkDirectory;
 			AndroidNdkDirectory = androidNdkDirectory;
 			JavaJdkDirectory = javaJdkDirectory;
 			AndroidSdkBuildToolsVersion = androidSdkBuildToolsVersion;
-			CMake = cmake;
 			HaveAllSdkPackages = haveAllSdkPackages;
 		}
 	}
@@ -62,14 +56,12 @@ namespace Outracks.AndroidManager
 					androidNdkDirectory: AbsoluteDirectoryPath.TryParse(someConfig.AndroidNdkDirectory),
 					javaJdkDirectory: AbsoluteDirectoryPath.TryParse(someConfig.JavaJdkDirectory),
 					androidSdkBuildToolsVersion: someConfig.AndroidSdkBuildToolsVersion.ToOptional(),
-					cmake: AbsoluteDirectoryPath.TryParse(someConfig.CMake),
 					haveAllSdkPackages: someConfig.HaveAllSdkPackages
 				);
 			}
 			else
 			{
 				return new OptionalSdkConfigOptions(
-					Optional.None(),
 					Optional.None(),
 					Optional.None(),
 					Optional.None(),
@@ -86,7 +78,6 @@ namespace Outracks.AndroidManager
 				AndroidNdkDirectory = sdkConfigOptions.AndroidNdkDirectory.Select(dir => dir.NativePath).Or((string) null),
 				JavaJdkDirectory = sdkConfigOptions.JavaJdkDirectory.Select(dir => dir.NativePath).Or((string) null),
 				AndroidSdkBuildToolsVersion = sdkConfigOptions.AndroidSdkBuildToolsVersion.Or((string) null),
-				CMake = sdkConfigOptions.CMake.Select(dir => dir.NativePath).Or((string)null),
 				HaveAllSdkPackages = sdkConfigOptions.HaveAllSdkPackages
 			};
 		}

--- a/Source/AndroidManager/SdkConfigOptions.cs
+++ b/Source/AndroidManager/SdkConfigOptions.cs
@@ -14,9 +14,6 @@ namespace Outracks.AndroidManager
 		[JsonProperty("Java.JDK.Directory")]
 		public string JavaJdkDirectory = null;
 
-		[JsonProperty("Android.SDK.BuildToolsVersion")]
-		public string AndroidSdkBuildToolsVersion = null;
-
 		[JsonProperty("HaveAllSDKPackages")]
 		public bool HaveAllSdkPackages = false;
 	}
@@ -26,20 +23,17 @@ namespace Outracks.AndroidManager
 		public Optional<AbsoluteDirectoryPath> AndroidSdkDirectory;
 		public Optional<AbsoluteDirectoryPath> AndroidNdkDirectory;
 		public Optional<AbsoluteDirectoryPath> JavaJdkDirectory;
-		public Optional<string> AndroidSdkBuildToolsVersion;
 		public bool HaveAllSdkPackages;
 
 		public OptionalSdkConfigOptions(
 			Optional<AbsoluteDirectoryPath> androidSdkDirectory, 
 			Optional<AbsoluteDirectoryPath> androidNdkDirectory, 
 			Optional<AbsoluteDirectoryPath> javaJdkDirectory, 
-			Optional<string> androidSdkBuildToolsVersion, 
 			bool haveAllSdkPackages)
 		{
 			AndroidSdkDirectory = androidSdkDirectory;
 			AndroidNdkDirectory = androidNdkDirectory;
 			JavaJdkDirectory = javaJdkDirectory;
-			AndroidSdkBuildToolsVersion = androidSdkBuildToolsVersion;
 			HaveAllSdkPackages = haveAllSdkPackages;
 		}
 	}
@@ -55,14 +49,12 @@ namespace Outracks.AndroidManager
 					androidSdkDirectory: AbsoluteDirectoryPath.TryParse(someConfig.AndroidSdkDirectory),
 					androidNdkDirectory: AbsoluteDirectoryPath.TryParse(someConfig.AndroidNdkDirectory),
 					javaJdkDirectory: AbsoluteDirectoryPath.TryParse(someConfig.JavaJdkDirectory),
-					androidSdkBuildToolsVersion: someConfig.AndroidSdkBuildToolsVersion.ToOptional(),
 					haveAllSdkPackages: someConfig.HaveAllSdkPackages
 				);
 			}
 			else
 			{
 				return new OptionalSdkConfigOptions(
-					Optional.None(),
 					Optional.None(),
 					Optional.None(),
 					Optional.None(),
@@ -77,7 +69,6 @@ namespace Outracks.AndroidManager
 				AndroidSdkDirectory = sdkConfigOptions.AndroidSdkDirectory.Select(dir => dir.NativePath).Or((string) null),
 				AndroidNdkDirectory = sdkConfigOptions.AndroidNdkDirectory.Select(dir => dir.NativePath).Or((string) null),
 				JavaJdkDirectory = sdkConfigOptions.JavaJdkDirectory.Select(dir => dir.NativePath).Or((string) null),
-				AndroidSdkBuildToolsVersion = sdkConfigOptions.AndroidSdkBuildToolsVersion.Or((string) null),
 				HaveAllSdkPackages = sdkConfigOptions.HaveAllSdkPackages
 			};
 		}

--- a/Source/AndroidManager/VerifyCommand.cs
+++ b/Source/AndroidManager/VerifyCommand.cs
@@ -44,13 +44,6 @@ namespace Outracks.AndroidManager
 				_progress.Report(new InstallerMessage("Failed to find Android Build tools."));
 			}
 
-			if (newConfig.CMake.HasValue == false)
-			{
-				failed = true;
-				_progress.Report(new InstallerMessage("Failed to find CMake."));
-			}
-
-
 			if (newConfig.HaveAllSdkPackages == false)
 			{
 				failed = true;

--- a/Source/AndroidManager/VerifyCommand.cs
+++ b/Source/AndroidManager/VerifyCommand.cs
@@ -38,12 +38,6 @@ namespace Outracks.AndroidManager
 				_progress.Report(new InstallerMessage("Failed to find NDK."));
 			}
 
-			if (newConfig.AndroidSdkBuildToolsVersion.HasValue == false)
-			{
-				failed = true;
-				_progress.Report(new InstallerMessage("Failed to find Android Build tools."));
-			}
-
 			if (newConfig.HaveAllSdkPackages == false)
 			{
 				failed = true;


### PR DESCRIPTION
This upgrades Android sdk-tools and removes out-dated packages. Apart from the sdk-tools and ndk-bundle, Gradle will automatically install required packages when building an app.

This PR includes:
- [ ] Change log
- [ ] Tests
