### PR TITLE
FuseImpl: don't think we're installed in debug mode

### DIFF
--- a/Source/Fuse/Common/FuseImpl.cs
+++ b/Source/Fuse/Common/FuseImpl.cs
@@ -52,7 +52,17 @@ namespace Outracks.Fuse
 		}
 
 		public string Version { get; set; }
-		public bool IsInstalled { get { return Version.Contains("-dev"); } }
+		public bool IsInstalled
+		{
+			get
+			{
+#if DEBUG
+				return false;
+#else
+				return Version.Contains("-dev");
+#endif
+			}
+		}
 
 
 		public AbsoluteDirectoryPath FuseRoot { get; set; }


### PR DESCRIPTION
This avoids receiving a false error message when trying to start Fuse Studio.

    Please don't run installed Fuse from inside the Fuse repository. It will get confused by .unoconfigs.

This PR includes:
- [ ] Change log
- [ ] Tests
