### PR TITLE
SketchImport autoresizing fix

### DIFF
--- a/Source/Sketch2Fuse/SketchConverter/SketchParser/SketchParserInternal.cs
+++ b/Source/Sketch2Fuse/SketchConverter/SketchParser/SketchParserInternal.cs
@@ -90,7 +90,7 @@ namespace SketchConverter.SketchParser
 
 		SketchAxisAlignment ParseAlignmentAxis(byte code)
 		{
-			return new SketchAxisAlignment(GetBit(code, 0), GetBit(code, 1), GetBit(code, 2));
+			return new SketchAxisAlignment(GetBit(code, 2), GetBit(code, 0), GetBit(code, 1));
 		}
 
 		SketchAlignment ParseAlignment(JObject layer)


### PR DESCRIPTION
There was the issue:
Generally import from sketch looks ok, but when you try to resize panel it works wrong.

- fix: sketch import autoresizing flags